### PR TITLE
Event loop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1961,6 +1961,13 @@
         "tslib": "^1.9.3"
       }
     },
+    "@syncot/event-loop": {
+      "version": "file:packages/event-loop",
+      "requires": {
+        "@types/node": "^12.0.4",
+        "tslib": "^1.9.3"
+      }
+    },
     "@syncot/ioredis-subscriber": {
       "version": "file:packages/ioredis-subscriber",
       "requires": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@syncot/auth-client": "file:packages/auth-client",
     "@syncot/client-storage": "file:packages/client-storage",
     "@syncot/connection": "file:packages/connection",
+    "@syncot/event-loop": "file:packages/event-loop",
     "@syncot/ioredis-subscriber": "file:packages/ioredis-subscriber",
     "@syncot/memory-client-storage": "file:packages/memory-client-storage",
     "@syncot/presence": "file:packages/presence",

--- a/packages/event-loop/package.json
+++ b/packages/event-loop/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@syncot/event-loop",
+  "version": "0.0.0",
+  "description": "A utility for IO-friendly task scheduling.",
+  "keywords": [
+    "util"
+  ],
+  "sideEffects": false,
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "/lib",
+    "!/lib/**/*.test.js",
+    "!/lib/**/*.test.d.ts"
+  ],
+  "author": "Greg Kubisa <gkubisa@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SyncOT/SyncOT.git"
+  },
+  "engines": {
+    "node": ">=12.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@types/node": "^12.0.4",
+    "tslib": "^1.9.3"
+  }
+}

--- a/packages/event-loop/src/eventLoop.test.ts
+++ b/packages/event-loop/src/eventLoop.test.ts
@@ -1,0 +1,94 @@
+import { delay } from '@syncot/util'
+import { globalEventLoop } from '.'
+
+const eventLoop = globalEventLoop()
+
+function blockEventLoop(): void {
+    while (eventLoop.cycleDuration <= eventLoop.cycleTargetDuration) {
+        // Block the event loop for a while.
+    }
+}
+
+beforeEach(async () => {
+    eventLoop.cycleTargetDuration = 10
+    await delay(0)
+})
+
+test('invalid cycleTargetDuration - a fraction', () => {
+    expect(() => (eventLoop.cycleTargetDuration = 122.5)).toThrow(
+        expect.objectContaining({
+            message: 'cycleTargetDuration must be a 32 bit integer.',
+            name: 'TypeError',
+        }),
+    )
+})
+
+test('invalid cycleTargetDuration - too small', () => {
+    expect(() => (eventLoop.cycleTargetDuration = 9)).toThrow(
+        expect.objectContaining({
+            message: 'cycleTargetDuration must be >= 10.',
+            name: 'RangeError',
+        }),
+    )
+})
+
+test('execute a task synchronously', () => {
+    eventLoop.cycleTargetDuration = 10000
+    const task = jest.fn()
+    expect(eventLoop.execute(task)).toBe(true)
+    expect(task).toHaveBeenCalledTimes(1)
+})
+
+test('schedule a task for the next cycle', async () => {
+    let resolve: jest.Mock
+    const promise = new Promise(r => (resolve = jest.fn(r)))
+    blockEventLoop()
+    expect(eventLoop.execute(resolve!)).toBe(false)
+    expect(resolve!).toHaveBeenCalledTimes(0)
+    await promise
+    expect(resolve!).toHaveBeenCalledTimes(1)
+})
+
+test('execute tasks after setting `cycleTargetDuration`', async () => {
+    const task1 = jest.fn()
+    const task2 = jest.fn()
+    blockEventLoop()
+    expect(eventLoop.execute(task1)).toBe(false)
+    expect(eventLoop.execute(task2)).toBe(false)
+    expect(task1).toHaveBeenCalledTimes(0)
+    expect(task2).toHaveBeenCalledTimes(0)
+    eventLoop.cycleTargetDuration = 1000000000
+    await delay(0)
+    expect(task1).toHaveBeenCalledTimes(1)
+    expect(task2).toHaveBeenCalledTimes(1)
+    expect(task1).toHaveBeenCalledBefore(task2)
+})
+
+test('run 2 scheduled tasks - no rescheduling', async () => {
+    const task1 = jest.fn()
+    const task2 = jest.fn()
+    blockEventLoop()
+    expect(eventLoop.execute(task1)).toBe(false)
+    expect(eventLoop.execute(task2)).toBe(false)
+    expect(task1).toHaveBeenCalledTimes(0)
+    expect(task2).toHaveBeenCalledTimes(0)
+    await delay(0)
+    expect(task1).toHaveBeenCalledTimes(1)
+    expect(task2).toHaveBeenCalledTimes(1)
+})
+
+test('run 2 scheduled tasks - reschedule the second task', async () => {
+    const task1 = jest.fn(blockEventLoop)
+    const task2 = jest.fn()
+    blockEventLoop()
+    expect(eventLoop.execute(task1)).toBe(false)
+    expect(eventLoop.execute(task2)).toBe(false)
+    expect(task1).toHaveBeenCalledTimes(0)
+    expect(task2).toHaveBeenCalledTimes(0)
+    await delay(0)
+    expect(task1).toHaveBeenCalledTimes(1)
+    expect(task2).toHaveBeenCalledTimes(0)
+    await delay(0)
+    expect(task1).toHaveBeenCalledTimes(1)
+    expect(task2).toHaveBeenCalledTimes(1)
+})

--- a/packages/event-loop/src/eventLoop.ts
+++ b/packages/event-loop/src/eventLoop.ts
@@ -1,0 +1,121 @@
+/**
+ * The type of tasks that can be executed by `EventLoop`.
+ */
+export type Task = () => void
+
+/**
+ * Provides IO-friendly task scheduling.
+ */
+export interface EventLoop {
+    /**
+     * The target cycle duration in milliseconds.
+     * The schduler will aim to process IO at least once per `cycleTargetDuration` milliseconds.
+     * The default value is 100.
+     * The min value is 10.
+     */
+    cycleTargetDuration: number
+    /**
+     * The duration of the current cycle in milliseconds.
+     */
+    readonly cycleDuration: number
+    /**
+     * The timestamp at which the current cycle started.
+     */
+    readonly cycleStartTime: number
+    /**
+     * Executes the `task` synchronously, if `cycleDuration <= cycleTargetDuration`.
+     * Otherwise schedules the `task` to execute when the event loop becomes idle.
+     * @param task The task to execute.
+     * @returns `true`, if the task has been executed synchronously, or `false`, if it has been scheduled for later.
+     */
+    execute(task: Task): boolean
+}
+
+export function globalEventLoop(): EventLoop {
+    return eventLoop
+}
+
+class Loop implements EventLoop {
+    public cycleStartTime: number = Date.now()
+
+    public get cycleDuration(): number {
+        return Date.now() - this.cycleStartTime
+    }
+
+    private _cycleTargetDuration: number = 100
+    public get cycleTargetDuration(): number {
+        return this._cycleTargetDuration
+    }
+    public set cycleTargetDuration(cycleTargetDuration: number) {
+        // tslint:disable-next-line:no-bitwise
+        if (cycleTargetDuration !== (cycleTargetDuration | 0)) {
+            throw new TypeError('cycleTargetDuration must be a 32 bit integer.')
+        }
+        if (cycleTargetDuration < 10) {
+            throw new RangeError('cycleTargetDuration must be >= 10.')
+        }
+        this._cycleTargetDuration = cycleTargetDuration
+
+        // Process the scheduled tasks at the new interval.
+        clearInterval(this.interval)
+        this.interval = setInterval(this.onInterval, this.cycleTargetDuration)
+        /* istanbul ignore else */
+        if (typeof this.interval.unref === 'function') {
+            // Allow nodejs to exit regardless of this timer.
+            this.interval.unref()
+        }
+
+        // Process the scheduled tasks once ASAP.
+        if (!this.timeout) {
+            this.timeout = setTimeout(this.onTimeout, 0)
+            /* istanbul ignore else */
+            if (typeof this.timeout.unref === 'function') {
+                // Allow nodejs to exit regardless of this timer.
+                this.timeout.unref()
+            }
+        }
+    }
+
+    private tasks: Task[] = []
+    private interval: NodeJS.Timeout
+    private timeout: NodeJS.Timeout | undefined = undefined
+
+    public constructor() {
+        this.interval = setInterval(this.onInterval, this.cycleTargetDuration)
+        /* istanbul ignore else */
+        if (typeof this.interval.unref === 'function') {
+            // Allow nodejs to exit regardless of this timer.
+            this.interval.unref()
+        }
+    }
+
+    public execute(task: Task): boolean {
+        if (this.cycleDuration <= this.cycleTargetDuration) {
+            task()
+            return true
+        } else {
+            this.tasks.push(task)
+            return false
+        }
+    }
+
+    private startCycle(): void {
+        this.cycleStartTime = Date.now()
+        const tasks = this.tasks
+        this.tasks = []
+        for (let i = 0, l = tasks.length; i < l; ++i) {
+            this.execute(tasks[i])
+        }
+    }
+
+    private onInterval = (): void => {
+        this.startCycle()
+    }
+
+    private onTimeout = (): void => {
+        this.timeout = undefined
+        this.startCycle()
+    }
+}
+
+const eventLoop = new Loop()

--- a/packages/event-loop/src/index.ts
+++ b/packages/event-loop/src/index.ts
@@ -1,0 +1,1 @@
+export * from './eventLoop'

--- a/packages/event-loop/tsconfig.json
+++ b/packages/event-loop/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib"
+  }
+}

--- a/packages/tson-socket-stream/package.json
+++ b/packages/tson-socket-stream/package.json
@@ -36,5 +36,8 @@
     "@types/readable-stream": "^2.3.1",
     "readable-stream": "^3.3.0",
     "tslib": "^1.9.3"
+  },
+  "peerDependencies": {
+    "@syncot/event-loop": "0.1.0"
   }
 }


### PR DESCRIPTION
When a lot of connections are opened and initialized at the same time, the event loop might get blocked for an extended period of time, leading to disconnects and even more connections to handle, as the clients try to reconnect. In order to avoid this vicious cycle, I modified the socket stream implementation, so that it delays request processing when the event loop can't keep up with the amount of work thrown at it. This ensures that other IO events are handled in a timely fashion, so that connections are maintained, health checks are handled successfully and the event loop has a chance to catch up.